### PR TITLE
Preserve "chr" prefix (if any) in output records

### DIFF
--- a/core.py
+++ b/core.py
@@ -300,7 +300,7 @@ class Record(object):
 
             # Creating first part of the VCF record (up to FILTER field)
             record = self.orig_chrom + '\t' + str(self.pos) + '\t' + self.id + '\t' + self.ref + '\t' + ",".join(
-                outalts) + '\t' + self.qual + '\t' + self.filter + '\t'
+                outalts) + '\t' + self.qual + '\t' + self.filter
 
             # Preparing components of the String to be added to the INFO field
             flags = []
@@ -327,9 +327,12 @@ class Record(object):
 
             # Adding second part of the VCF record (starting from the INFO field)
             if self.info == '.' or self.info == '':
-                record += added + '\t' + "\t".join(self.rest)
+                record += '\t' + added
             else:
-                record += self.info + ';' + added + '\t' + "\t".join(self.rest)
+                record += '\t' + self.info + ';' + added
+
+            if len(self.rest) > 0:
+                record += '\t' + "\t".join(self.rest)
 
             # Writing record to the output file
             if stdout:

--- a/core.py
+++ b/core.py
@@ -167,7 +167,7 @@ class Record(object):
         # Parsing VCF format
         if options.args['inputformat'].upper() == 'VCF':
             cols = line.strip().split("\t")
-            self.chrom = cols[0]
+            self.orig_chrom = self.chrom = cols[0]
             if self.chrom.startswith('chr'): self.chrom = self.chrom[3:]
             self.pos = int(cols[1])
             self.id = cols[2]
@@ -189,7 +189,7 @@ class Record(object):
         if options.args['inputformat'].upper() == 'TXT':
             cols = line.strip().split("\t")
             self.id = cols[0]
-            self.chrom = cols[1]
+            self.orig_chrom = self.chrom = cols[1]
             self.pos = int(cols[2])
             self.ref = cols[3]
             self.alts = []
@@ -299,7 +299,7 @@ class Record(object):
         if outformat.upper() == 'VCF':
 
             # Creating first part of the VCF record (up to FILTER field)
-            record = self.chrom + '\t' + str(self.pos) + '\t' + self.id + '\t' + self.ref + '\t' + ",".join(
+            record = self.orig_chrom + '\t' + str(self.pos) + '\t' + self.id + '\t' + self.ref + '\t' + ",".join(
                 outalts) + '\t' + self.qual + '\t' + self.filter + '\t'
 
             # Preparing components of the String to be added to the INFO field
@@ -344,7 +344,7 @@ class Record(object):
             c = 0
             for variant in outvariants:
                 # Creating first part of the TSV record (up to FILTER field)
-                record = self.id + '\t' + self.chrom + '\t' + str(self.pos) + '\t' + self.ref + '\t' + outalts[
+                record = self.id + '\t' + self.orig_chrom + '\t' + str(self.pos) + '\t' + self.ref + '\t' + outalts[
                     c] + '\t' + self.qual + '\t' + self.filter
 
                 # Number of transcripts overlapping with the variant


### PR DESCRIPTION
When reading a VCF file with “chr5”-style chromosome names, CAVA removes the “chr” so that the chromosomes used internally will match its Ensembl database.  It then outputs the records into the output VCF sans “chr”, but with the input file's `##contig=<ID=chr5,…>` headers, leading to confused downstream analysis that's expecting the “chr5”-style names.

This patch records the original input chromosome name used, and prints it out in both VCF and TSV records.  If during processing `self.chrom` might change then this would be a problem, but this seems unlikely.  I considered instead recording the original prefix and re-adding it on output, but the `orig_chrom` approach also allows e.g. canonicalising “M” as “MT” internally.

Also a tiny change to avoid trailing tab characters on output VCF records.